### PR TITLE
Fix: Weird additional field in the dashboard

### DIFF
--- a/packages/application/src/application/use-cases/create-application/subscribe-application-submissions.service.ts
+++ b/packages/application/src/application/use-cases/create-application/subscribe-application-submissions.service.ts
@@ -24,11 +24,12 @@ export async function subscribeApplicationSubmissions(container: Container) {
       for (const record of newRecords) {
         if (shouldProcessRecord(record, processedRecords)) {
           const command = mapRecordToCommand(record)
-          await commandBus.send(command)
           processedRecords.add(record.id)
+          await commandBus.send(command)
         }
       }
     } catch (error) {
+      processedRecords.clear()
       console.error('Error processing application submissions:', error)
     }
   }, config.SUBSCRIBE_APPLICATION_SUBMISSIONS_POLLING_INTERVAL)


### PR DESCRIPTION
Fixed a race condition in the polling loop where await "commandBus.send(command)" could delay adding the record to the "processed" list, causing duplicate processing and creation of redundant broken entities. Now the ID is added before await — ensuring reliable and idempotent behaviour.

