### PR TITLE
Make applciation IDs an index so that upserting works as expected

### DIFF
--- a/packages/application/src/api/index.ts
+++ b/packages/application/src/api/index.ts
@@ -47,6 +47,7 @@ async function main() {
   const db = container.get<Db>(TYPES.Db)
   // await db.collection('applicationDetails').deleteMany({})
   // await db.collection('datacap-allocator-events').deleteMany({})
+  await db.collection('applicationDetails').createIndex({ applicationId: 1 }, { unique: true });
 
   // Bind the API server to the container
   const apiServer = server.build()


### PR DESCRIPTION
Fixes the observed issue with junk entries showing up in the front end.

Also fixes a much worse issue that the Mongo collection was being broken in the back end.