### PR TITLE
Dont allocate DC to allocators when isMDMAAllocator is checked (#1)

### DIFF
--- a/packages/application/src/application/events/handlers/index.ts
+++ b/packages/application/src/application/events/handlers/index.ts
@@ -1,7 +1,7 @@
 import { IEventHandler } from '@filecoin-plus/core'
 import { inject, injectable } from 'inversify'
 import { Db } from 'mongodb'
-import { getMultisigInfo } from '@src/infrastructure/clients/filfox';
+import { getMultisigInfo } from '@src/infrastructure/clients/filfox'
 
 import {
   AllocatorMultisigUpdated,
@@ -20,11 +20,15 @@ import {
   MetaAllocatorApprovalStarted,
   MetaAllocatorApprovalCompleted,
   DatacapRefreshRequested,
-  KYCRevoked
+  KYCRevoked,
 } from '@src/domain/application/application.events'
 import { TYPES } from '@src/types'
 import { IApplicationDetailsRepository } from '@src/infrastructure/respositories/application-details.repository'
-import { ApplicationStatus, ApplicationAllocator, ApplicationInstructionStatus } from '@src/domain/application/application'
+import {
+  ApplicationStatus,
+  ApplicationAllocator,
+  ApplicationInstructionStatus,
+} from '@src/domain/application/application'
 import { ApplicationDetails } from '@src/infrastructure/respositories/application-details.types'
 
 @injectable()
@@ -32,7 +36,8 @@ export class ApplicationEditedEventHandler implements IEventHandler<ApplicationE
   public event = ApplicationEdited.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
   ) {}
 
   async handle(event: ApplicationEdited): Promise<void> {
@@ -45,7 +50,10 @@ export class ApplicationEditedEventHandler implements IEventHandler<ApplicationE
       github: event.file.application.github_handles[0],
       // xDONE
       applicationInstructions: Object.entries(event.file.audit_outcomes).map(([_, value]) => ({
-        method: event.file.metapathway_type === "MA" ? ApplicationAllocator.META_ALLOCATOR : ApplicationAllocator.RKH_ALLOCATOR,
+        method:
+          event.file.metapathway_type === 'MA'
+            ? ApplicationAllocator.META_ALLOCATOR
+            : ApplicationAllocator.RKH_ALLOCATOR,
         timestamp: parseInt(value[0]),
         datacap_amount: parseInt(value[1]),
       })),
@@ -65,7 +73,8 @@ export class ApplicationPullRequestUpdatedEventHandler implements IEventHandler<
   public event = ApplicationPullRequestUpdated.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
   ) {}
 
   async handle(event: ApplicationPullRequestUpdated): Promise<void> {
@@ -85,32 +94,30 @@ export class AllocatorMultisigUpdatedEventHandler implements IEventHandler<Alloc
   public event = AllocatorMultisigUpdated.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
   ) {}
 
   async handle(event: AllocatorMultisigUpdated): Promise<void> {
-      let signers: string[] = [];
-      let threshold = 0;
-      try {
-        const msigData = await getMultisigInfo(event.multisigAddress);
-        signers   = msigData.multisig?.signers   ?? [];
-        threshold = msigData.multisig?.approvalThreshold ?? 0;
-      } catch (err) {
-        console.error(
-          `Failed to fetch multisig info for ${event.multisigAddress}:`,
-          err,
-        );
-      }
+    let signers: string[] = []
+    let threshold = 0
+    try {
+      const msigData = await getMultisigInfo(event.multisigAddress)
+      signers = msigData.multisig?.signers ?? []
+      threshold = msigData.multisig?.approvalThreshold ?? 0
+    } catch (err) {
+      console.error(`Failed to fetch multisig info for ${event.multisigAddress}:`, err)
+    }
 
-      await this._repository.update({
-        id:        event.aggregateId,
-        actorId:   event.allocatorActorId,
-        address:   event.multisigAddress,
-        multisigDetails: {
-          multisigThreshold: threshold,
-          multisigSigners: signers
-        }
-      });
+    await this._repository.update({
+      id: event.aggregateId,
+      actorId: event.allocatorActorId,
+      address: event.multisigAddress,
+      multisigDetails: {
+        multisigThreshold: threshold,
+        multisigSigners: signers,
+      },
+    })
   }
 }
 @injectable()
@@ -118,8 +125,9 @@ export class KYCStartedEventHandler implements IEventHandler<KYCStarted> {
   public event = KYCStarted.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: KYCStarted): Promise<void> {
     this._repository.update({
@@ -134,8 +142,9 @@ export class KYCRevokedEventHandler implements IEventHandler<KYCRevoked> {
   public event = KYCRevoked.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: KYCRevoked): Promise<void> {
     this._repository.update({
@@ -150,8 +159,9 @@ export class KYCApprovedEventHandler implements IEventHandler<KYCApproved> {
   public event = KYCApproved.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: KYCApproved): Promise<void> {
     await this._repository.update({
@@ -166,8 +176,9 @@ export class KYCRejectedEventHandler implements IEventHandler<KYCRejected> {
   public event = KYCRejected.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: KYCRejected): Promise<void> {
     await this._repository.update({
@@ -182,8 +193,9 @@ export class GovernanceReviewStartedEventHandler implements IEventHandler<Govern
   public event = GovernanceReviewStarted.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: GovernanceReviewStarted): Promise<void> {
     await this._repository.update({
@@ -197,7 +209,7 @@ export class GovernanceReviewStartedEventHandler implements IEventHandler<Govern
 export class GovernanceReviewApprovedEventHandler implements IEventHandler<GovernanceReviewApproved> {
   public event = GovernanceReviewApproved.name
 
-  constructor(@inject(TYPES.Db) private readonly _db: Db) { }
+  constructor(@inject(TYPES.Db) private readonly _db: Db) {}
 
   async handle(event: GovernanceReviewApproved): Promise<void> {
     const applicationInstructions = event.applicationInstructions
@@ -205,9 +217,10 @@ export class GovernanceReviewApprovedEventHandler implements IEventHandler<Gover
     const lastInstructionMethod = lastInstruction.method
     const lastInstructionAmount = lastInstruction.datacap_amount
 
-    const status = lastInstructionMethod === ApplicationAllocator.META_ALLOCATOR
-      ? ApplicationStatus.META_APPROVAL_PHASE
-      : ApplicationStatus.RKH_APPROVAL_PHASE
+    const status =
+      lastInstructionMethod === ApplicationAllocator.META_ALLOCATOR
+        ? ApplicationStatus.META_APPROVAL_PHASE
+        : ApplicationStatus.RKH_APPROVAL_PHASE
 
     await this._db.collection('applicationDetails').updateOne(
       { id: event.aggregateId },
@@ -226,7 +239,7 @@ export class GovernanceReviewApprovedEventHandler implements IEventHandler<Gover
 export class GovernanceReviewRejectedEventHandler implements IEventHandler<GovernanceReviewRejected> {
   public event = GovernanceReviewRejected.name
 
-  constructor(@inject(TYPES.Db) private readonly _db: Db) { }
+  constructor(@inject(TYPES.Db) private readonly _db: Db) {}
 
   async handle(event: GovernanceReviewRejected): Promise<void> {
     // Update allocator status in the database
@@ -247,7 +260,8 @@ export class MetaAllocatorApprovalStartedEventHandler implements IEventHandler<M
   public event = MetaAllocatorApprovalStarted.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
   ) {}
 
   async handle(event: MetaAllocatorApprovalStarted): Promise<void> {
@@ -257,14 +271,13 @@ export class MetaAllocatorApprovalStartedEventHandler implements IEventHandler<M
       status: ApplicationStatus.META_APPROVAL_PHASE,
     })
   }
-
 }
 
 @injectable()
 export class MetaAllocatorApprovalCompletedEventHandler implements IEventHandler<MetaAllocatorApprovalCompleted> {
   public event = MetaAllocatorApprovalCompleted.name
 
-  constructor(@inject(TYPES.Db) private readonly _db: Db) { }
+  constructor(@inject(TYPES.Db) private readonly _db: Db) {}
 
   async handle(event: MetaAllocatorApprovalCompleted) {
     console.log('MetaAllocatorApprovalCompletedEventHandler', event)
@@ -282,7 +295,6 @@ export class MetaAllocatorApprovalCompletedEventHandler implements IEventHandler
       },
     )
   }
-
 }
 
 @injectable()
@@ -290,8 +302,9 @@ export class RKHApprovalStartedEventHandler implements IEventHandler<RKHApproval
   public event = RKHApprovalStarted.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: RKHApprovalStarted): Promise<void> {
     await this._repository.update({
@@ -310,8 +323,9 @@ export class RKHApprovalsUpdatedEventHandler implements IEventHandler<RKHApprova
   public event = RKHApprovalsUpdated.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: RKHApprovalsUpdated) {
     console.log('RKHApprovalsUpdatedEventHandler', event)
@@ -332,7 +346,7 @@ export class RKHApprovalsUpdatedEventHandler implements IEventHandler<RKHApprova
 export class RKHApprovalCompletedEventHandler implements IEventHandler<RKHApprovalCompleted> {
   public event = RKHApprovalCompleted.name
 
-  constructor(@inject(TYPES.Db) private readonly _db: Db) { }
+  constructor(@inject(TYPES.Db) private readonly _db: Db) {}
 
   async handle(event: RKHApprovalCompleted) {
     // Update allocator status in the database
@@ -353,8 +367,9 @@ export class DatacapAllocationUpdatedEventHandler implements IEventHandler<Datac
   public event = DatacapAllocationUpdated.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: DatacapAllocationUpdated) {
     console.log('DatacapAllocationUpdatedEventHandler', event)
@@ -372,8 +387,9 @@ export class DatacapRefreshRequestedEventHandler implements IEventHandler<Dataca
   public event = DatacapRefreshRequested.name
 
   constructor(
-    @inject(TYPES.ApplicationDetailsRepository) private readonly _repository: IApplicationDetailsRepository,
-  ) { }
+    @inject(TYPES.ApplicationDetailsRepository)
+    private readonly _repository: IApplicationDetailsRepository,
+  ) {}
 
   async handle(event: DatacapRefreshRequested) {
     console.log('DatacapRefreshRequestedEventHandler', event)
@@ -386,7 +402,7 @@ export class DatacapRefreshRequestedEventHandler implements IEventHandler<Dataca
         datacap_amount: event.amount,
         status: ApplicationInstructionStatus.PENDING,
         timestamp: event.timestamp.getTime(),
-      }
+      },
     ]
 
     await this._repository.update({

--- a/packages/application/src/domain/application/application.ts
+++ b/packages/application/src/domain/application/application.ts
@@ -1,32 +1,37 @@
 import { AggregateRoot, ApplicationError, IEventStore, IRepository } from '@filecoin-plus/core'
 import { StatusCodes } from 'http-status-codes'
 
+import { ApplicationPullRequestFile } from '@src/application/services/pull-request.types'
 import {
-  GovernanceReviewStarted,
-  KYCStarted,
-  KYCApproved,
-  KYCRejected,
-  GovernanceReviewApproved,
-  GovernanceReviewRejected,
-  RKHApprovalStarted,
-  DatacapAllocationUpdated,
-  RKHApprovalsUpdated,
-  RKHApprovalCompleted,
-  MetaAllocatorApprovalStarted,
-  MetaAllocatorApprovalCompleted,
+  GovernanceReviewApprovedData,
+  GovernanceReviewRejectedData,
+  KYCApprovedData,
+  KYCRejectedData,
+} from '@src/domain/types'
+import {
+  AllocatorMultisigUpdated,
   ApplicationCreated,
   ApplicationEdited,
   ApplicationPullRequestUpdated,
-  AllocatorMultisigUpdated,
+  DatacapAllocationUpdated,
   DatacapRefreshRequested,
-  KYCRevoked
+  GovernanceReviewApproved,
+  GovernanceReviewRejected,
+  GovernanceReviewStarted,
+  KYCApproved,
+  KYCRejected,
+  KYCRevoked,
+  KYCStarted,
+  MetaAllocatorApprovalCompleted,
+  MetaAllocatorApprovalStarted,
+  RKHApprovalCompleted,
+  RKHApprovalStarted,
+  RKHApprovalsUpdated,
 } from './application.events'
-import { KYCApprovedData, KYCRejectedData, GovernanceReviewApprovedData, GovernanceReviewRejectedData } from '@src/domain/types'
-import { ApplicationPullRequestFile } from '@src/application/services/pull-request.types'
 
-export interface IDatacapAllocatorRepository extends IRepository<DatacapAllocator> { }
+export interface IDatacapAllocatorRepository extends IRepository<DatacapAllocator> {}
 
-export interface IDatacapAllocatorEventStore extends IEventStore<DatacapAllocator> { }
+export interface IDatacapAllocatorEventStore extends IEventStore<DatacapAllocator> {}
 
 export enum ApplicationStatus {
   KYC_PHASE = 'KYC_PHASE',
@@ -66,6 +71,7 @@ export type ApplicationInstruction = {
   datacap_amount: number
   timestamp?: number
   status?: string
+  isMDMAAllocator?: boolean
 }
 
 export enum ApplicationInstructionStatus {
@@ -80,7 +86,7 @@ export type ApplicationGrantCycle = {
   pullRequest: ApplicationPullRequest
   instruction: ApplicationInstruction
 }
-export type StatusEvent = { stage: string; timestamp: number };
+export type StatusEvent = { stage: string; timestamp: number }
 
 export class DatacapAllocator extends AggregateRoot {
   public applicationNumber: number
@@ -132,11 +138,11 @@ export class DatacapAllocator extends AggregateRoot {
   public onChainAddressForDataCapAllocation: string
 
   public status: { [key: string]: number | null } = {
-    "Application Submitted": null,
-    "KYC Submitted": null,
-    "Approved": null,
-    "Declined": null,
-    "DC Allocated": null
+    'Application Submitted': null,
+    'KYC Submitted': null,
+    Approved: null,
+    Declined: null,
+    'DC Allocated': null,
   }
 
   /*public status: { [stage: string]: number[]|null} = {
@@ -200,14 +206,9 @@ export class DatacapAllocator extends AggregateRoot {
   }
 
   edit(file: ApplicationPullRequestFile) {
-    this.ensureValidApplicationStatus([
-      ApplicationStatus.KYC_PHASE,
-      ApplicationStatus.GOVERNANCE_REVIEW_PHASE,
-    ])   
+    this.ensureValidApplicationStatus([ApplicationStatus.KYC_PHASE, ApplicationStatus.GOVERNANCE_REVIEW_PHASE])
     console.log('edit')
-    this.applyChange(
-      new ApplicationEdited(this.guid, file),
-    )
+    this.applyChange(new ApplicationEdited(this.guid, file))
   }
 
   setAllocatorMultisig(
@@ -221,7 +222,6 @@ export class DatacapAllocator extends AggregateRoot {
     this.applyChange(
       new AllocatorMultisigUpdated(this.guid, allocatorActorId, multisigAddress, multisigThreshold, multisigSigners),
     )
-   
   }
 
   setApplicationPullRequest(
@@ -233,22 +233,26 @@ export class DatacapAllocator extends AggregateRoot {
     console.log('setApplicationPullRequest', this.applicationStatus)
     if (!refresh) {
       this.ensureValidApplicationStatus([ApplicationStatus.KYC_PHASE])
-      this.applyChange(new ApplicationPullRequestUpdated(
-        this.guid,
-        pullRequestNumber,
-        pullRequestUrl,
-        commentId,
-        ApplicationStatus.KYC_PHASE,
-      ))
+      this.applyChange(
+        new ApplicationPullRequestUpdated(
+          this.guid,
+          pullRequestNumber,
+          pullRequestUrl,
+          commentId,
+          ApplicationStatus.KYC_PHASE,
+        ),
+      )
     } else {
       this.ensureValidApplicationStatus([ApplicationStatus.APPROVED])
-      this.applyChange(new ApplicationPullRequestUpdated(
-        this.guid,
-        pullRequestNumber,
-        pullRequestUrl,
-        commentId,
-        ApplicationStatus.GOVERNANCE_REVIEW_PHASE,
-      ))
+      this.applyChange(
+        new ApplicationPullRequestUpdated(
+          this.guid,
+          pullRequestNumber,
+          pullRequestUrl,
+          commentId,
+          ApplicationStatus.GOVERNANCE_REVIEW_PHASE,
+        ),
+      )
     }
   }
 
@@ -286,30 +290,42 @@ export class DatacapAllocator extends AggregateRoot {
           the tooling field should get "smart_contract_allocator" entry
           the application should advance to MA approval
     */
-    const approvedMethod = details?.allocatorType === 'Manual' ? ApplicationAllocator.META_ALLOCATOR : ApplicationAllocator.RKH_ALLOCATOR
+    const approvedMethod =
+      details?.allocatorType === 'Manual' ? ApplicationAllocator.META_ALLOCATOR : ApplicationAllocator.RKH_ALLOCATOR
     const lastInstructionIndex = this.applicationInstructions.length - 1
     this.applicationInstructions[lastInstructionIndex].method = approvedMethod
     this.applicationInstructions[lastInstructionIndex].datacap_amount = details?.finalDataCap
     this.applicationInstructions[lastInstructionIndex].status = ApplicationInstructionStatus.PENDING
+    this.applicationInstructions[lastInstructionIndex].isMDMAAllocator = details?.isMDMAAllocator
+
     //this.applicationInstructions[lastInstructionIndex].timestamp = Math.floor(Date.now() / 1000)
 
     this.applyChange(new GovernanceReviewApproved(this.guid, this.applicationInstructions))
-    if (this.applicationInstructions[lastInstructionIndex].method === ApplicationAllocator.META_ALLOCATOR) {
-      this.applyChange(new MetaAllocatorApprovalStarted(this.guid))
-    } else {
-      this.applyChange(new RKHApprovalStarted(this.guid, 2)) // TODO: Hardcoded 2 for multisig threshold
+
+    const isMetaAllocator =
+      this.applicationInstructions[lastInstructionIndex].method === ApplicationAllocator.META_ALLOCATOR
+    const isMDMA = details?.isMDMAAllocator
+
+    const action = () => {
+      if (isMetaAllocator && isMDMA)
+        return new MetaAllocatorApprovalCompleted(this.guid, 0, '', this.applicationInstructions)
+      if (isMetaAllocator && !isMDMA) return new MetaAllocatorApprovalStarted(this.guid)
+      if (!isMetaAllocator && isMDMA) return new RKHApprovalCompleted(this.guid, this.applicationInstructions)
+      return new RKHApprovalStarted(this.guid, 2) // TODO: Hardcoded 2 for multisig threshold
     }
+
+    this.applyChange(action())
   }
 
-rejectGovernanceReview(details: GovernanceReviewRejectedData) {
-  this.ensureValidApplicationStatus([ApplicationStatus.GOVERNANCE_REVIEW_PHASE])
+  rejectGovernanceReview(details: GovernanceReviewRejectedData) {
+    this.ensureValidApplicationStatus([ApplicationStatus.GOVERNANCE_REVIEW_PHASE])
 
-  const lastInstructionIndex = this.applicationInstructions.length - 1
-  this.applicationInstructions[lastInstructionIndex].status = ApplicationInstructionStatus.DENIED
-  this.applyChange(new GovernanceReviewRejected(this.guid, this.applicationInstructions))
-}
+    const lastInstructionIndex = this.applicationInstructions.length - 1
+    this.applicationInstructions[lastInstructionIndex].status = ApplicationInstructionStatus.DENIED
+    this.applyChange(new GovernanceReviewRejected(this.guid, this.applicationInstructions))
+  }
 
-/*
+  /*
   approveGovernanceReview(details: GovernanceReviewApprovedData) {
     this.ensureValidApplicationStatus([ApplicationStatus.GOVERNANCE_REVIEW_PHASE])    
     this.ensureValidApplicationInstructions([
@@ -403,7 +419,7 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
     console.log('updateDatacapAllocation')
     try {
       this.completeRKHApproval()
-    } catch (error) { }
+    } catch (error) {}
     // TODO: this.applyChange(new DatacapAllocationUpdated(this.guid, datacap));
   }
 
@@ -417,7 +433,6 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
     const refreshMethod = prevInstruction.method
 
     this.applyChange(new DatacapRefreshRequested(this.guid, refreshAmount, refreshMethod))
-
   }
   applyApplicationCreated(event: ApplicationCreated) {
     //console.log('applyApplicationCreated', event)
@@ -460,39 +475,44 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
 
     this.applicantOrgName = event.file.organization || this.applicantOrgName
 
-    if(this.applicationStatus === ApplicationStatus.META_APPROVAL_PHASE){
-      this.allocationTooling = ["smart_contract_allocator"]
+    if (this.applicationStatus === ApplicationStatus.META_APPROVAL_PHASE) {
+      this.allocationTooling = ['smart_contract_allocator']
       this.pathway = 'MA'
       this.ma_address = '0xB6F5d279AEad97dFA45209F3E53969c2EF43C21d'
     }
-    if(this.applicationStatus === ApplicationStatus.RKH_APPROVAL_PHASE){
-      this.allocationTooling = [],
-      this.pathway = 'RKH',
-      this.ma_address = 'f080'
+    if (this.applicationStatus === ApplicationStatus.RKH_APPROVAL_PHASE) {
+      ;(this.allocationTooling = []), (this.pathway = 'RKH'), (this.ma_address = 'f080')
     }
     this.applicantOrgAddresses = event.file.associated_org_addresses || this.applicantOrgAddresses
-    this.allocationStandardizedAllocations = event.file.application.allocations || this.allocationStandardizedAllocations
-    this.allocationAudit = event.file.application.audit && event.file.application.audit.length > 0
-      ? event.file.application.audit[0]
-      : this.allocationAudit
-    this.allocationDistributionRequired = event.file.application.distribution && event.file.application.distribution.length > 0
-      ? event.file.application.distribution[0]
-      : this.allocationDistributionRequired
+    this.allocationStandardizedAllocations =
+      event.file.application.allocations || this.allocationStandardizedAllocations
+    this.allocationAudit =
+      event.file.application.audit && event.file.application.audit.length > 0
+        ? event.file.application.audit[0]
+        : this.allocationAudit
+    this.allocationDistributionRequired =
+      event.file.application.distribution && event.file.application.distribution.length > 0
+        ? event.file.application.distribution[0]
+        : this.allocationDistributionRequired
     this.allocationTrancheSchedule = event.file.application.tranche_schedule || this.allocationTrancheSchedule
     this.allocationRequiredReplicas = event.file.application.required_replicas || this.allocationRequiredReplicas
-    this.allocationRequiredStorageProviders = event.file.application.required_sps || this.allocationRequiredStorageProviders
+    this.allocationRequiredStorageProviders =
+      event.file.application.required_sps || this.allocationRequiredStorageProviders
     this.allocationMaxDcClient = event.file.application.max_DC_client || this.allocationMaxDcClient
-    this.applicantGithubHandle = event.file.application.github_handles && event.file.application.github_handles.length > 0
-      ? event.file.application.github_handles[0]
-      : this.applicantGithubHandle
+    this.applicantGithubHandle =
+      event.file.application.github_handles && event.file.application.github_handles.length > 0
+        ? event.file.application.github_handles[0]
+        : this.applicantGithubHandle
     this.allocationBookkeepingRepo = event.file.application.allocation_bookkeeping || this.allocationBookkeepingRepo
-    this.onChainAddressForDataCapAllocation = event.file.application.client_contract_address || this.onChainAddressForDataCapAllocation
-    
+    this.onChainAddressForDataCapAllocation =
+      event.file.application.client_contract_address || this.onChainAddressForDataCapAllocation
+
     this.allocatorMultisigAddress = event.file.pathway_addresses?.msig || this.allocatorMultisigAddress
     this.allocatorMultisigSigners = event.file.pathway_addresses?.signers || this.allocatorMultisigSigners
 
     this.applicationInstructions = Object.entries(event.file.audit_outcomes).map(([_, value]) => ({
-      method: event.file.metapathway_type === "MA" ? ApplicationAllocator.META_ALLOCATOR : ApplicationAllocator.RKH_ALLOCATOR,
+      method:
+        event.file.metapathway_type === 'MA' ? ApplicationAllocator.META_ALLOCATOR : ApplicationAllocator.RKH_ALLOCATOR,
       datacap_amount: parseInt(value[1]),
       timestamp: parseInt(value[0]),
     }))
@@ -509,17 +529,16 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
 
   applyApplicationPullRequestUpdated(event: ApplicationPullRequestUpdated) {
     console.log('applyApplicationPullRequestUpdated')
-    
+
     this.applicationPullRequest = {
       prNumber: event.prNumber,
       prUrl: event.prUrl,
       commentId: event.commentId,
       timestamp: event.timestamp,
     }
-    if (this.status["Application Submitted"]===null) {
-      this.status["Application Submitted"]=event.timestamp.getTime()
+    if (this.status['Application Submitted'] === null) {
+      this.status['Application Submitted'] = event.timestamp.getTime()
     }
-
   }
 
   applyKYCStarted(_: KYCStarted) {
@@ -529,33 +548,33 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
 
   applyKYCApproved(event: KYCApproved) {
     console.log(' applyKYCApproved')
-    if (this.applicationStatus===ApplicationStatus.KYC_PHASE) {
-      this.status["KYC Submitted"] ??= event.timestamp.getTime()
+    if (this.applicationStatus === ApplicationStatus.KYC_PHASE) {
+      this.status['KYC Submitted'] ??= event.timestamp.getTime()
       this.applicationStatus = ApplicationStatus.GOVERNANCE_REVIEW_PHASE
     }
   }
-//check that it should be KYCApproved. 
+  //check that it should be KYCApproved.
   applyKYCRevoked(_: KYCApproved) {
     this.applicationStatus = ApplicationStatus.GOVERNANCE_REVIEW_PHASE
-    this.status["KYC Submitted"] = null
+    this.status['KYC Submitted'] = null
   }
 
   applyKYCRejected(event: KYCRejected) {
-    this.status["KYC Failed"] = event.timestamp.getTime()
+    this.status['KYC Failed'] = event.timestamp.getTime()
   }
 
   applyGovernanceReviewStarted(event: GovernanceReviewStarted) {
     console.log('applyGovernanceReviewStarted')
     if (this.applicationStatus === ApplicationStatus.IN_REFRESH) {
-      this.status["In Refresh"] ??= event.timestamp.getTime()
+      this.status['In Refresh'] ??= event.timestamp.getTime()
       this.applicationStatus = ApplicationStatus.GOVERNANCE_REVIEW_PHASE
     }
   }
 
   applyGovernanceReviewApproved(event: GovernanceReviewApproved) {
     console.log('applyGovernanceReviewApproved')
-     if (this.applicationStatus === ApplicationStatus.GOVERNANCE_REVIEW_PHASE) {
-      this.status["Approved"] ??= event.timestamp.getTime()
+    if (this.applicationStatus === ApplicationStatus.GOVERNANCE_REVIEW_PHASE) {
+      this.status['Approved'] ??= event.timestamp.getTime()
     }
     //this.applicationStatus = ApplicationStatus.APPROVED
     this.applicationInstructions = event.applicationInstructions
@@ -563,17 +582,15 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
 
   applyGovernanceReviewRejected(event: GovernanceReviewRejected) {
     this.applicationStatus = ApplicationStatus.REJECTED
-    if (!this.status["Declined"]) {
-      this.status["Declined"]=event.timestamp.getTime()
+    if (!this.status['Declined']) {
+      this.status['Declined'] = event.timestamp.getTime()
     }
   }
 
   applyRKHApprovalStarted(event: RKHApprovalStarted) {
     console.log('applyRKHApprovalStarted')
     this.applicationStatus = ApplicationStatus.RKH_APPROVAL_PHASE
-    this.allocationTooling = [],
-    this.pathway = 'RKH',
-    this.ma_address = 'f080'
+    ;(this.allocationTooling = []), (this.pathway = 'RKH'), (this.ma_address = 'f080')
     this.rkhApprovalThreshold = event.approvalThreshold
   }
 
@@ -589,8 +606,8 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
   }
 
   applyRKHApprovalCompleted(event: RKHApprovalCompleted) {
-    if(this.applicationStatus === ApplicationStatus.RKH_APPROVAL_PHASE){
-      this.status["DC Allocated"] ??= event.timestamp.getTime()
+    if (this.applicationStatus === ApplicationStatus.RKH_APPROVAL_PHASE) {
+      this.status['DC Allocated'] ??= event.timestamp.getTime()
     }
     this.applicationStatus = ApplicationStatus.DC_ALLOCATED
     //const index = this.applicationInstructions.length - 1
@@ -601,14 +618,14 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
 
   applyMetaAllocatorApprovalStarted(event: MetaAllocatorApprovalStarted) {
     this.applicationStatus = ApplicationStatus.META_APPROVAL_PHASE
-    this.allocationTooling = ["smart_contract_allocator"]
+    this.allocationTooling = ['smart_contract_allocator']
     this.pathway = 'MA'
     this.ma_address = '0xB6F5d279AEad97dFA45209F3E53969c2EF43C21d'
   }
 
   applyMetaAllocatorApprovalCompleted(event: MetaAllocatorApprovalCompleted) {
-    if(this.applicationStatus === ApplicationStatus.META_APPROVAL_PHASE){
-      this.status["DC Allocated"] ??= event.timestamp.getTime()
+    if (this.applicationStatus === ApplicationStatus.META_APPROVAL_PHASE) {
+      this.status['DC Allocated'] ??= event.timestamp.getTime()
     }
     this.applicationStatus = ApplicationStatus.DC_ALLOCATED
 
@@ -616,7 +633,6 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
     this.applicationInstructions[index].timestamp = event.timestamp.getTime()
     this.applicationInstructions[index].status = ApplicationInstructionStatus.GRANTED
     this.applicationInstructions[index].datacap_amount = event.applicationInstructions[index].datacap_amount
-
   }
 
   applyDatacapAllocationUpdated(event: DatacapAllocationUpdated) {
@@ -627,7 +643,7 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
   applyDatacapRefreshRequested(event: DatacapRefreshRequested) {
     console.log('applyDatacapRefreshRequested', this.applicationStatus)
     if (this.applicationStatus === ApplicationStatus.DC_ALLOCATED) {
-      this.status["In Refresh"] ??= event.timestamp.getTime()
+      this.status['In Refresh'] ??= event.timestamp.getTime()
     }
     this.applicationStatus = ApplicationStatus.GOVERNANCE_REVIEW_PHASE
     this.applicationInstructions.push({
@@ -655,12 +671,11 @@ rejectGovernanceReview(details: GovernanceReviewRejectedData) {
     errorCode: string = '5308',
     errorMessage: string = 'Invalid application instructions for the current phase',
   ): void {
-
     if (this.applicationInstructions.length === 0) {
       throw new ApplicationError(StatusCodes.BAD_REQUEST, errorCode, 'Empty instruction data')
     }
 
-    const lastInstruction = this.applicationInstructions[this.applicationInstructions.length - 1];
+    const lastInstruction = this.applicationInstructions[this.applicationInstructions.length - 1]
     let instructionMethod: string
     let instructionAmount: number
     try {

--- a/packages/application/src/domain/types.ts
+++ b/packages/application/src/domain/types.ts
@@ -32,9 +32,11 @@ export type GovernanceReviewApprovedData = {
   finalDataCap: number
   allocatorType: AllocatorType
   reviewerAddress: string
+  isMDMAAllocator: boolean
 }
 
 export type GovernanceReviewRejectedData = {
   reason: string
   reviewerAddress: string
+  isMDMAAllocator: boolean
 }


### PR DESCRIPTION
**Issue:** 
Don't allocate DC to allocators, migrating over from the old JSON schema

**Solution:** 
When `isMDMAAllocator` is true, change the metaallocator application or RKH application status to `APPROVED` instead of `META_APPROVAL_PHASE` or `RKH_APPROVAL_PHASE`

**Changes:**
- in `approveGovernanceReview` function
- `isMDMAAllocator` flag + db

**Rest changes - it's only prettier auto-formatter**

Related to:

https://github.com/fidlabs/rkh-frontend/pull/29