### PR TITLE
Convert audits/application instructions to new more sustainable format

### DIFF
--- a/packages/application/src/application/use-cases/refresh-rkh-datacap/subscribe-refresh-rkh.service.ts
+++ b/packages/application/src/application/use-cases/refresh-rkh-datacap/subscribe-refresh-rkh.service.ts
@@ -80,6 +80,7 @@ export async function submitRefreshRKHAllocatorCommand(
     let lastInstruction: ApplicationInstruction
     let lastInstructionMethod: string
     let lastInstructionAmount: number
+    // FIXME This is where we need to find the latest one by date and/or status, not just length
     try {
         applicationInstructionsLength = applicationDetails.applicationInstructions.length
         lastInstruction = applicationDetails.applicationInstructions[applicationInstructionsLength - 1]

--- a/packages/application/src/testing/gov-review.ts
+++ b/packages/application/src/testing/gov-review.ts
@@ -35,6 +35,7 @@ async function main() {
 
     let applicationId = 'app-test-1731240427'
     const testEdit = false
+    // TODO this test has rotted, no longer reflects updates to structures
     const applicationInstructions = [
         {
             method: 'RKH_ALLOCATOR',

--- a/packages/application/src/testing/ma-refresh.ts
+++ b/packages/application/src/testing/ma-refresh.ts
@@ -438,6 +438,7 @@ async function testSubmitRefreshMetaAllocatorCommand(container: Container) {
         allocationTrancheSchedule: 'type',
         datacap: 0,
         status: ApplicationStatus.APPROVED,
+        // TODO this test has rotted, no longer reflects updates to structures
         applicationInstructions: [
             {
                 datacap_amount: initialDatacap,

--- a/packages/application/src/testing/rkh-refresh.ts
+++ b/packages/application/src/testing/rkh-refresh.ts
@@ -65,6 +65,7 @@ async function testSubmitRefreshRKHAllocatorCommand(
         allocationTrancheSchedule: 'type',
         datacap: 0,
         status: ApplicationStatus.APPROVED,
+        // TODO this test has rotted, no longer reflects updates to structures
         applicationInstructions: [
             {
                 datacap_amount: initialDatacap,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,3 +20,4 @@ export * from './interfaces/IReadModelFacade';
 export * from './interfaces/IRepository';
 export * from './utilities/EventProcessor';
 export * from './utilities/Logger';
+export * from './utilities/TimeUtils';

--- a/packages/core/src/utilities/TimeUtils.ts
+++ b/packages/core/src/utilities/TimeUtils.ts
@@ -1,0 +1,32 @@
+/**
+ * Convert an epoch timestamp (seconds or milliseconds) to an ISO 8601 Zulu string.
+ *
+ * If the input is ≤ 1e12 it’s assumed to be seconds; otherwise milliseconds.
+ *
+ * @param epoch – Number of seconds or milliseconds since Unix epoch.
+ * @returns ISO 8601 timestamp in Zulu (UTC)
+ */
+export function epochToZulu(epoch: number): string {
+  const ms = epoch > 1e12 ? epoch : epoch * 1000;
+  const d = new Date(ms);
+  if (isNaN(d.getTime())) {
+    console.log(`Error in epochToZulu: Invalid timestamp: "${epoch}"`);
+    return "1970-01-01T00:00:01Z";
+  }
+  return d.toISOString();
+}
+
+/**
+ * Convert an ISO 8601 Zulu string to a Unix epoch timestamp in seconds.
+ *
+ * @param zulu – ISO 8601 timestamp, e.g. "2025-05-15T17:25:32Z" or with milliseconds.
+ * @returns Number of seconds since Unix epoch, or 0 on error.
+ */
+export function zuluToEpoch(zulu: string): number {
+  const ms = Date.parse(zulu);
+  if (isNaN(ms)) {
+    console.log(`Error in zuluToEpoch: Invalid Zulu timestamp: "${zulu}"`);
+    return 0;
+  }
+  return Math.floor(ms / 1000);
+}


### PR DESCRIPTION
Note I've dropped some FIXMEs in here where I haven't made things any _worse_, but there are dragons lurking in the array management code, for example. It will only bite us when a refresh of a new format Allocator happens so can be addressed along with implementing the remainder of refresh