### PR TITLE
[Fil] - simplified error messages from github client

### DIFF
--- a/packages/application/src/api/http/controllers/refresh.controller.ts
+++ b/packages/application/src/api/http/controllers/refresh.controller.ts
@@ -68,7 +68,7 @@ export class RefreshController {
     const result = await this._commandBus.send(new UpsertIssueCommand(issueDetails));
 
     if (!result?.success) {
-      return res.status(400).json(badRequest(RES.FAILED_TO_UPSERT_ISSUE, result?.error));
+      return res.status(400).json(badRequest(RES.FAILED_TO_UPSERT_ISSUE, [result.error.message]));
     }
     return res.json(ok(RES.UPSERTED_ISSUE));
   }

--- a/packages/application/src/application/use-cases/refresh-issues/upsert-issue.command.test.ts
+++ b/packages/application/src/application/use-cases/refresh-issues/upsert-issue.command.test.ts
@@ -141,7 +141,8 @@ describe('UpsertIssueCommand', () => {
     expect(result).toStrictEqual({
       success: false,
       error: expect.objectContaining({
-        message: 'Issue does not have a jsonNumber',
+        message:
+          'The JSON number or hash does not exist in the issue template, or it has been added incorrectly.',
       }),
     });
   });

--- a/packages/application/src/application/use-cases/refresh-issues/upsert-issue.command.ts
+++ b/packages/application/src/application/use-cases/refresh-issues/upsert-issue.command.ts
@@ -3,12 +3,13 @@ import { inject, injectable } from 'inversify';
 import { IssueDetails } from '@src/infrastructure/respositories/issue-details';
 import { TYPES } from '@src/types';
 import { IIssueDetailsRepository } from '@src/infrastructure/respositories/issue-details.repository';
-import { LOG_MESSAGES } from '@src/constants';
+import { LOG_MESSAGES, RESPONSE_MESSAGES } from '@src/constants';
 import { FetchAllocatorCommand } from '@src/application/use-cases/fetch-allocator/fetch-allocator.command';
 import { IIssueMapper } from '@src/infrastructure/mappers/issue-mapper';
 import { ApplicationPullRequestFile } from '@src/application/services/pull-request.types';
 
 const LOG = LOG_MESSAGES.UPSERT_ISSUE_COMMAND;
+const RES = RESPONSE_MESSAGES.UPSERT_ISSUE_COMMAND;
 
 export class UpsertIssueCommand extends Command {
   constructor(public readonly githubIssue: IssueDetails) {
@@ -57,7 +58,7 @@ export class UpsertIssueCommandCommandHandler implements ICommandHandler<UpsertI
   async connectAllocatorToIssue(issueDetails: IssueDetails): Promise<IssueDetails> {
     this.logger.info(LOG.CONNECTING_ALLOCATOR_TO_ISSUE);
 
-    if (!issueDetails.jsonNumber) throw new Error('Issue does not have a jsonNumber');
+    if (!issueDetails.jsonNumber) throw new Error(RES.JSON_HASH_IS_NOT_FOUND_OR_INCORRECT);
 
     const commandResponse = await this.commandBus.send(
       new FetchAllocatorCommand(issueDetails.jsonNumber),

--- a/packages/application/src/constants/log-messages.ts
+++ b/packages/application/src/constants/log-messages.ts
@@ -47,7 +47,6 @@ export const LOG_MESSAGES = {
     ALLOCATOR_FILE_RETRIEVED: '[FetchAllocatorCommand]: Allocator retrieved successfully',
     ALLOCATOR_FILE_MAPPING: '[FetchAllocatorCommand]: Mapping allocator file',
     ALLOCATOR_FILE_MAPPED: '[FetchAllocatorCommand]: Allocator file mapped successfully',
-    ALLOCATOR_NOT_FOUND: '[FetchAllocatorCommand]: Allocator not found',
     FAILED_TO_GET_ALLOCATOR: '[FetchAllocatorCommand]: Failed to get allocator',
   },
 

--- a/packages/application/src/constants/response-messages.ts
+++ b/packages/application/src/constants/response-messages.ts
@@ -8,4 +8,12 @@ export const RESPONSE_MESSAGES = {
     REFRESH_SUCCESS: 'Refresh successful',
     REFRESH_FAILED: 'Refresh failed',
   },
+  FETCH_ALLOCATOR_COMMAND: {
+    ALLOCATOR_NOT_FOUND: 'The Allocator could not be found for the given JSON number or hash',
+    DEFAULT_ERROR: 'Failed to fetch JSON number',
+  },
+  UPSERT_ISSUE_COMMAND: {
+    JSON_HASH_IS_NOT_FOUND_OR_INCORRECT:
+      'The JSON number or hash does not exist in the issue template, or it has been added incorrectly.',
+  },
 };


### PR DESCRIPTION
- The error messages have been updated to return human-readable text.

before:
<img width="515" height="348" alt="Screenshot from 2025-07-24 13-06-28" src="https://github.com/user-attachments/assets/9ba8ef26-3c3e-451c-8410-6ef08badf7c3" />

after:
<img width="549" height="132" alt="Screenshot from 2025-07-24 13-07-02" src="https://github.com/user-attachments/assets/8ec18d63-e5d6-4831-bf1b-fc14f1ce54a2" />
