### PR TITLE
[FIL-993] Added an endpoint to retrieve structured meta-allocator data.

### DIFF
--- a/packages/application/src/api/http/controllers/index.ts
+++ b/packages/application/src/api/http/controllers/index.ts
@@ -2,3 +2,4 @@ export * from './application.controller';
 export * from './kyc.controller';
 export * from './role.controller';
 export * from './refresh.controller';
+export * from './meta-allocator.controller';

--- a/packages/application/src/api/http/controllers/meta-allocator.controller.ts
+++ b/packages/application/src/api/http/controllers/meta-allocator.controller.ts
@@ -1,0 +1,25 @@
+import { controller, httpGet, request, response } from 'inversify-express-utils';
+import { Request, Response } from 'express';
+import { ok } from '@src/api/http/processors/response';
+import { MetaAllocatorService } from '@src/application/services/meta-allocator.service';
+import { TYPES } from '@src/types';
+import { inject } from 'inversify';
+import { LOG_MESSAGES, RESPONSE_MESSAGES } from '@src/constants';
+import { Logger } from '@filecoin-plus/core';
+
+const LOG = LOG_MESSAGES.MA_CONTROLLER;
+const RES = RESPONSE_MESSAGES.MA_CONTROLLER;
+
+@controller('/api/v1/ma')
+export class MetaAllocatorController {
+  constructor(
+    @inject(TYPES.MetaAllocatorService) private readonly metaAllocatorService: MetaAllocatorService,
+    @inject(TYPES.Logger) private readonly logger: Logger,
+  ) {}
+
+  @httpGet('')
+  async getMetaAllocatorAddresses(@request() req: Request, @response() res: Response) {
+    this.logger.info(LOG.FETCHING_MA_ADDRESSES);
+    return res.json(ok(RES.MA_ADDRESSES_RETRIEVED, this.metaAllocatorService.getAll()));
+  }
+}

--- a/packages/application/src/application/services/meta-allocator.service.test.ts
+++ b/packages/application/src/application/services/meta-allocator.service.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MetaAllocatorService } from './meta-allocator.service';
+import { Container } from 'inversify';
+import { IMetaAllocatorRepository } from '@src/infrastructure/repositories/meta-allocator.repository';
+import { TYPES } from '@src/types';
+
+describe('MetaAllocatorService', () => {
+  let container: Container;
+  let service: MetaAllocatorService;
+
+  const fixtureMetaAllocators = [
+    {
+      name: 'MDMA',
+      ethAddress: '0x1',
+      filAddress: 'f1',
+      ethSafeAddress: '0x2',
+      filSafeAddress: 'f2',
+      signers: ['0x3'],
+    },
+  ];
+
+  const metaAllocatorRepositoryMock = {
+    getAll: vi.fn(),
+  };
+
+  beforeEach(() => {
+    container = new Container();
+    container
+      .bind<IMetaAllocatorRepository>(TYPES.MetaAllocatorRepository)
+      .toConstantValue(metaAllocatorRepositoryMock as unknown as IMetaAllocatorRepository);
+
+    container.bind<MetaAllocatorService>(TYPES.MetaAllocatorService).to(MetaAllocatorService);
+
+    service = container.get<MetaAllocatorService>(TYPES.MetaAllocatorService);
+
+    metaAllocatorRepositoryMock.getAll.mockReturnValue(fixtureMetaAllocators);
+  });
+
+  it('getAll should return list from repository', () => {
+    const result = service.getAll();
+
+    expect(result).toBe(fixtureMetaAllocators);
+    expect(metaAllocatorRepositoryMock.getAll).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/application/src/application/services/meta-allocator.service.ts
+++ b/packages/application/src/application/services/meta-allocator.service.ts
@@ -1,0 +1,22 @@
+import {
+  MetaAllocator,
+  MetaAllocatorRepository,
+} from '@src/infrastructure/repositories/meta-allocator.repository';
+import { TYPES } from '@src/types';
+import { inject, injectable } from 'inversify';
+
+export interface IMetaAllocatorService {
+  getAll(): readonly MetaAllocator[];
+}
+
+@injectable()
+export class MetaAllocatorService implements IMetaAllocatorService {
+  constructor(
+    @inject(TYPES.MetaAllocatorRepository)
+    private readonly metaAllocatorRepository: MetaAllocatorRepository,
+  ) {}
+
+  getAll(): readonly MetaAllocator[] {
+    return this.metaAllocatorRepository.getAll();
+  }
+}

--- a/packages/application/src/constants/log-messages.ts
+++ b/packages/application/src/constants/log-messages.ts
@@ -67,4 +67,8 @@ export const LOG_MESSAGES = {
     REFRESH_APPROVED: '[ApproveRefreshByMaCommand]: Refresh approved successfully',
     FAILED_TO_APPROVE_REFRESH: '[ApproveRefreshByMaCommand]: Failed to approve refresh',
   },
+
+  MA_CONTROLLER: {
+    FETCHING_MA_ADDRESSES: '[MaController]: Fetching MetaAllocator addresses',
+  },
 };

--- a/packages/application/src/constants/response-messages.ts
+++ b/packages/application/src/constants/response-messages.ts
@@ -16,4 +16,7 @@ export const RESPONSE_MESSAGES = {
     JSON_HASH_IS_NOT_FOUND_OR_INCORRECT:
       'The JSON number or hash does not exist in the issue template, or it has been added incorrectly.',
   },
+  MA_CONTROLLER: {
+    MA_ADDRESSES_RETRIEVED: 'MetaAllocator addresses retrieved successfully',
+  },
 };

--- a/packages/application/src/e2e/api/meta-allocator/get-all.e2e.test.ts
+++ b/packages/application/src/e2e/api/meta-allocator/get-all.e2e.test.ts
@@ -1,0 +1,64 @@
+import 'reflect-metadata';
+import request from 'supertest';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { Application, json, urlencoded } from 'express';
+import { InversifyExpressServer } from 'inversify-express-utils';
+import '@src/api/http/controllers/meta-allocator.controller';
+import * as dotenv from 'dotenv';
+import { TestContainerBuilder } from '@mocks/builders';
+
+process.env.NODE_ENV = 'test';
+dotenv.config({ path: '.env.test' });
+
+describe('GET /api/v1/ma', () => {
+  let app: Application;
+
+  beforeAll(async () => {
+    const testBuilder = new TestContainerBuilder();
+    const testSetup = testBuilder.withLogger().withRepositories().withServices().build();
+
+    const server = new InversifyExpressServer(testSetup.container);
+    server.setConfig((app: Application) => {
+      app.use(urlencoded({ extended: true }));
+      app.use(json());
+    });
+
+    app = server.build();
+    app.listen();
+  });
+
+  it('should return meta-allocator addresses', async () => {
+    const response = await request(app).get('/api/v1/ma');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toStrictEqual({
+      status: '200',
+      message: 'MetaAllocator addresses retrieved successfully',
+      data: [
+        {
+          name: 'MDMA',
+          ethAddress: '0xB6F5d279AEad97dFA45209F3E53969c2EF43C21d',
+          filAddress: 'f410fw325e6novwl57jcsbhz6koljylxuhqq5jnp5ftq',
+          ethSafeAddress: '0x2e25A2f6bC2C0b7669DFB25180Ed57e07dAabe9e',
+          filSafeAddress: 'f410ffys2f5v4fqfxm2o7wjiyb3kx4b62vpu66gmu7ia',
+          signers: [
+            '0x6D16eAf8Ad9dA277Cb33C53528fb977ab93D5A2e',
+            '0x106A371ab66ACA71753757eBD9Bb0a323e055229',
+            '0xDABAe878B6D1045a9417Eaf2cc4280Dbc510f3f6',
+          ],
+        },
+        {
+          name: 'ODMA',
+          ethAddress: '0xE896C15F5120A07C2481e0fcf3d008E1C9E76C1f',
+          filAddress: 'f410f5clmcx2recqhyjeb4d6phuai4he6o3a77guvfny',
+          ethSafeAddress: '0xfeaCBca666CA237F01F0B192fB9F43D61F32F41a',
+          filSafeAddress: 'f410f72wlzjtgzirx6apqwgjpxh2d2yptf5a2f6ns7gi',
+          signers: [
+            '0x7285B7D3248fde1cCF9E087993fdfC79EC54b54a',
+            '0xDABAe878B6D1045a9417Eaf2cc4280Dbc510f3f6',
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/application/src/e2e/api/refresh/get--all-refreshes.e2e.test.ts
+++ b/packages/application/src/e2e/api/refresh/get--all-refreshes.e2e.test.ts
@@ -26,6 +26,8 @@ describe('GET /api/v1/refreshes', () => {
       .withEventBus()
       .withCommandBus()
       .withQueryBus()
+      .withMappers()
+      .withServices()
       .withGithubClient()
       .withRepositories()
       .withCommandHandlers()

--- a/packages/application/src/e2e/api/refresh/put--upsert-from-issue.e2e.test.ts
+++ b/packages/application/src/e2e/api/refresh/put--upsert-from-issue.e2e.test.ts
@@ -45,6 +45,8 @@ describe('Refresh from Issue E2E', () => {
       .withCommandBus()
       .withQueryBus()
       .withGithubClient(githubMock as unknown as IGithubClient)
+      .withMappers()
+      .withServices()
       .withRepositories()
       .withCommandHandlers()
       .withQueryHandlers()

--- a/packages/application/src/infrastructure/module.ts
+++ b/packages/application/src/infrastructure/module.ts
@@ -33,6 +33,10 @@ import {
   RpcProviderConfig,
 } from '@src/infrastructure/clients/rpc-provider';
 import { DataCapMapper, IDataCapMapper } from '@src/infrastructure/mappers/data-cap-mapper';
+import {
+  IMetaAllocatorRepository,
+  MetaAllocatorRepository,
+} from './repositories/meta-allocator.repository';
 
 export const infrastructureModule = new AsyncContainerModule(async (bind: interfaces.Bind) => {
   // MongoDB setup
@@ -93,6 +97,9 @@ export const infrastructureModule = new AsyncContainerModule(async (bind: interf
     .inSingletonScope();
   bind<IIssueDetailsRepository>(TYPES.IssueDetailsRepository)
     .to(IssueDetailsRepository)
+    .inSingletonScope();
+  bind<IMetaAllocatorRepository>(TYPES.MetaAllocatorRepository)
+    .to(MetaAllocatorRepository)
     .inSingletonScope();
   bind<ICommandBus>(TYPES.CommandBus).toConstantValue(new CommandBus());
   bind<IQueryBus>(TYPES.QueryBus).toConstantValue(new QueryBus());

--- a/packages/application/src/infrastructure/repositories/meta-allocator.repository.ts
+++ b/packages/application/src/infrastructure/repositories/meta-allocator.repository.ts
@@ -1,0 +1,58 @@
+import { injectable } from 'inversify';
+
+export interface MetaAllocator {
+  readonly name: string;
+  readonly signers: readonly string[];
+  readonly ethAddress: string;
+  readonly ethSafeAddress: string;
+  readonly filAddress: string;
+  readonly filSafeAddress: string;
+}
+
+export interface IMetaAllocatorRepository {
+  getAll(): readonly MetaAllocator[];
+}
+
+@injectable()
+export class MetaAllocatorRepository implements IMetaAllocatorRepository {
+  private readonly metaAllocators: MetaAllocator[] = [
+    {
+      name: 'MDMA',
+      ethAddress: '0xB6F5d279AEad97dFA45209F3E53969c2EF43C21d',
+      filAddress: 'f410fw325e6novwl57jcsbhz6koljylxuhqq5jnp5ftq',
+      ethSafeAddress: '0x2e25A2f6bC2C0b7669DFB25180Ed57e07dAabe9e',
+      filSafeAddress: 'f410ffys2f5v4fqfxm2o7wjiyb3kx4b62vpu66gmu7ia',
+      signers: [
+        '0x6D16eAf8Ad9dA277Cb33C53528fb977ab93D5A2e',
+        '0x106A371ab66ACA71753757eBD9Bb0a323e055229',
+        '0xDABAe878B6D1045a9417Eaf2cc4280Dbc510f3f6',
+      ],
+    },
+    {
+      name: 'ODMA',
+      ethAddress: '0xE896C15F5120A07C2481e0fcf3d008E1C9E76C1f',
+      filAddress: 'f410f5clmcx2recqhyjeb4d6phuai4he6o3a77guvfny',
+      ethSafeAddress: '0xfeaCBca666CA237F01F0B192fB9F43D61F32F41a',
+      filSafeAddress: 'f410f72wlzjtgzirx6apqwgjpxh2d2yptf5a2f6ns7gi',
+      signers: [
+        '0x7285B7D3248fde1cCF9E087993fdfC79EC54b54a',
+        '0xDABAe878B6D1045a9417Eaf2cc4280Dbc510f3f6',
+      ],
+    },
+    // EPMA: {
+    //   name: 'EPMA',
+    //   ethAddress: '0x1e15357F252FF44d2CebEA99FDB1E0858018cCE1',
+    //   filAddress: 'f410fdyktk7zff72e2lhl5km73mpaqwabrthbajj3l5q',
+    //   ethSafeAddress: '0x8AaDA793DB9dF62ba4703F16c73a2E14949B0AE8',
+    //   filSafeAddress: 'f410frkw2pe63tx3cxjdqh4lmoorocskjwcxidsi7c3i',
+    //   signers: [
+    //     '0x7285B7D3248fde1cCF9E087993fdfC79EC54b54a',
+    //     '0xDABAe878B6D1045a9417Eaf2cc4280Dbc510f3f6',
+    //   ],
+    // },
+  ];
+
+  getAll(): readonly MetaAllocator[] {
+    return this.metaAllocators;
+  }
+}

--- a/packages/application/src/startup.ts
+++ b/packages/application/src/startup.ts
@@ -75,6 +75,7 @@ import { FetchAllocatorCommandHandler } from '@src/application/use-cases/fetch-a
 import { SignRefreshByRKHCommandHandler } from '@src/application/use-cases/update-rkh-approvals/sign-refresh-by-rkh.command';
 import { ApproveRefreshByRKHCommandHandler } from '@src/application/use-cases/update-rkh-approvals/approve-refresh-by-rkh.command';
 import { ApproveRefreshByMaCommandHandler } from '@src/application/use-cases/update-ma-approvals/approve-refresh-by-ma.command';
+import { MaService } from './application/services/meta-allocator.service';
 
 export const initialize = async (): Promise<Container> => {
   const container = new Container();
@@ -88,6 +89,7 @@ export const initialize = async (): Promise<Container> => {
   container.bind<PullRequestService>(TYPES.PullRequestService).to(PullRequestService);
   container.bind<RoleService>(TYPES.RoleService).to(RoleService);
   container.bind<MessageService>(TYPES.MessageService).to(MessageService);
+  container.bind<MaService>(TYPES.MaService).to(MaService);
 
   container.bind<IEventHandler<ApplicationCreated>>(TYPES.Event).to(ApplicationCreatedEventHandler);
   container.bind<IEventHandler<ApplicationEdited>>(TYPES.Event).to(ApplicationEditedEventHandler);

--- a/packages/application/src/testing/mocks/builders/test-container-builder.ts
+++ b/packages/application/src/testing/mocks/builders/test-container-builder.ts
@@ -27,6 +27,15 @@ import { BulkCreateIssueCommandHandler } from '@src/application/use-cases/refres
 import { UpsertIssueCommandCommandHandler } from '@src/application/use-cases/refresh-issues/upsert-issue.command';
 import { GetRefreshesQueryHandler } from '@src/application/queries/get-refreshes/get-refreshes.query';
 import { FetchAllocatorCommandHandler } from '@src/application/use-cases/fetch-allocator/fetch-allocator.command';
+import {
+  IMetaAllocatorRepository,
+  MetaAllocatorRepository,
+} from '@src/infrastructure/repositories/meta-allocator.repository';
+import { DataCapMapper, IDataCapMapper } from '@src/infrastructure/mappers/data-cap-mapper';
+import {
+  MetaAllocatorService,
+  IMetaAllocatorService,
+} from '@src/application/services/meta-allocator.service';
 
 export class TestContainerBuilder {
   private container: Container;
@@ -73,13 +82,28 @@ export class TestContainerBuilder {
     return this;
   }
 
+  withMappers() {
+    this.container.bind<IIssueMapper>(TYPES.IssueMapper).to(IssueMapper).inSingletonScope();
+    this.container.bind<IDataCapMapper>(TYPES.DataCapMapper).to(DataCapMapper).inSingletonScope();
+    return this;
+  }
+
   withRepositories() {
     this.container
       .bind<IIssueDetailsRepository>(TYPES.IssueDetailsRepository)
       .to(IssueDetailsRepository)
       .inSingletonScope();
 
-    this.container.bind<IIssueMapper>(TYPES.IssueMapper).to(IssueMapper).inSingletonScope();
+    this.container
+      .bind<IMetaAllocatorRepository>(TYPES.MetaAllocatorRepository)
+      .to(MetaAllocatorRepository)
+      .inSingletonScope();
+
+    return this;
+  }
+
+  withServices() {
+    this.container.bind<IMetaAllocatorService>(TYPES.MetaAllocatorService).to(MetaAllocatorService);
     return this;
   }
 

--- a/packages/application/src/types.ts
+++ b/packages/application/src/types.ts
@@ -28,4 +28,6 @@ export const TYPES = {
   RpcProvider: Symbol('RpcProvider'),
   RpcProviderConfig: Symbol('RpcProviderConfig'),
   DataCapMapper: Symbol('DataCapMapper'),
+  MetaAllocatorService: Symbol('MetaAllocatorService'),
+  MetaAllocatorRepository: Symbol('MetaAllocatorRepository'),
 };

--- a/packages/application/vitest.e2e.config.ts
+++ b/packages/application/vitest.e2e.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/e2e/**/*.e2e.{js,ts}'],
+    include: ['src/e2e/**/*.e2e.test.{js,ts}'],
     exclude: ['node_modules', 'dist', '.git'],
     testTimeout: 30000,
     hookTimeout: 30000,


### PR DESCRIPTION
- added service and repository for scallability
- added controller with /ma endpoint
- hardcoded the structures of the meta-alctors because they will never change anyway, and they are public. I just want them in one place so that I don't have to change the FE every time I test a new MA on the testnet.