### PR TITLE
Allow text strings in RPC calls

### DIFF
--- a/packages/application/src/api/index.ts
+++ b/packages/application/src/api/index.ts
@@ -37,20 +37,20 @@ async function main() {
     app.use(corsMiddleware);
     app.use(urlencoded({ extended: true }));
     app.use(json());
-    
+
     // Add raw body parsing for RPC endpoint
     app.use('/api/v1/rpc', (req, res, next) => {
       const contentType = req.headers['content-type'] || '';
-      
+
       if (contentType.includes('text/plain')) {
         // For text/plain, we need to get the raw body
         let rawData = '';
         req.setEncoding('utf8');
-        
-        req.on('data', (chunk) => {
+
+        req.on('data', chunk => {
           rawData += chunk;
         });
-        
+
         req.on('end', () => {
           try {
             console.log('Raw text/plain body:', rawData);


### PR DESCRIPTION
Some clients send JSON, some send text-encoded JSON. Allow both.